### PR TITLE
Create the parent directory if it doesn't exist

### DIFF
--- a/src/Handlebars/FluentHandlebars.cs
+++ b/src/Handlebars/FluentHandlebars.cs
@@ -126,7 +126,10 @@ namespace Genyman.Core.Handlebars
 			}
 			try
 			{
-				File.WriteAllText(fileName, result, System.Text.Encoding.UTF8);
+			    var directoryName = Path.GetDirectoryName(fileName);
+			    Directory.CreateDirectory(directoryName);
+
+			    File.WriteAllText(fileName, result, System.Text.Encoding.UTF8);
 				return fileName;
 			}
 			catch (Exception e)


### PR DESCRIPTION
When the template contains nested directories and files and genyman tries to write one of the nested files, it will throw an exception because a part of the path doesn't exist.
This PR will ensure that genyman first creates the parent directories recursively if they don't exist yet.